### PR TITLE
Fix generics and trailing newline

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -13,5 +13,5 @@ __all__ = [
     "calculate_wilks_scores",
     "get_wilks_value",
     "calculate_user_weight_class",
-    "get_weight_class_options"
+    "get_weight_class_options",
 ]

--- a/models/wilks.py
+++ b/models/wilks.py
@@ -1,6 +1,6 @@
 import logging
 from functools import cache
-from typing import Literal
+from typing import Literal, TypeVar
 
 import polars as pl
 
@@ -48,7 +48,10 @@ JUNIOR_WEIGHT_CLASSES = {
     "F": (43.0, "43kg")
 }
 
-def wilks_polynomial[T](coefficients: tuple, bodyweight: T) -> T:
+T = TypeVar("T")
+
+
+def wilks_polynomial(coefficients: tuple[float, ...], bodyweight: T) -> T:
     """
     Calculate Wilks score using the provided coefficients and bodyweight.
 

--- a/services/cache_service.py
+++ b/services/cache_service.py
@@ -5,9 +5,11 @@ import time
 import zlib
 from collections import OrderedDict
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeVar
 
 from services.config_service import config
+
+T = TypeVar("T")
 
 # Configure logging
 logging.basicConfig(
@@ -223,10 +225,10 @@ class CacheService:
         except Exception as e:
             return self._handle_cache_error('Cache storage error: ', e, False)
 
-    def _handle_cache_error[T](self, arg0: str, e: BaseException, arg2: T) -> T:
-        logger.error(f"{arg0}{e}")
+    def _handle_cache_error(self, msg: str, e: BaseException, default: T) -> T:
+        logger.error(f"{msg}{e}")
         self.stats['errors'] += 1
-        return arg2
+        return default
 
     def _clean_old_files(self) -> None:
         """Clean up old cache files."""


### PR DESCRIPTION
## Summary
- correct TypeVar usage for Wilks computations
- fix cache service error handling generics
- ensure models package has trailing newline for linting

## Testing
- `ruff check . --ignore E501`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6841ead50d14832e8f2fe00e503967d7